### PR TITLE
[CP-3774] Update amazon-mws gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gemspec
 
 group :test do
   gem 'minitest'
-  gem 'mocha'
+  gem 'mocha', '>= 1.4.0'
 
   platform :ruby_19 do
     gem 'simplecov'

--- a/amazon-mws.gemspec
+++ b/amazon-mws.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency "ruby-hmac", "~> 0.4.0"
-  s.add_dependency "roxml", ">= 3.3.1"
+  s.add_dependency "roxml", "~> 4.0.0"
   s.add_dependency "xml-simple", "~> 1.1.1"
   s.add_dependency "builder", ">= 3.0.0"
 end

--- a/amazon-mws.gemspec
+++ b/amazon-mws.gemspec
@@ -3,7 +3,7 @@ $:.push File.expand_path("../lib", __FILE__)
 
 Gem::Specification.new do |s|
   s.name = %q{amazon-mws}
-  s.version = "0.1.1.2"
+  s.version = "0.1.1.3"
 
   s.authors     = ["David Michael", "A. Edward Wible", "Alex Stubbs"]
   s.email       = ["david.michael@sonymusic.com", "aewible@gmail.com", "alex@alex-s.co.uk"]

--- a/amazon-mws.gemspec
+++ b/amazon-mws.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency "ruby-hmac", "~> 0.4.0"
-  s.add_dependency "roxml", "~> 3.3.1"
+  s.add_dependency "roxml", ">= 3.3.1"
   s.add_dependency "xml-simple", "~> 1.1.1"
   s.add_dependency "builder", ">= 3.0.0"
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -12,7 +12,7 @@ require 'minitest/autorun'
 require 'pathname'
 require 'yaml'
 #require 'fakeweb'
-require 'mocha/mini_test'
+require 'mocha/minitest'
 
 require File.join(File.dirname(__FILE__), '..', 'lib', 'amazon', 'mws')
 


### PR DESCRIPTION
As we would like to use this gem with Ruby 2.4 or newer versions we should let to use newer roxml gem, because roxml 4 has a ruby 2.4 support.